### PR TITLE
Add parquet preview notebook

### DIFF
--- a/notebooks/03_preview_parquets.ipynb
+++ b/notebooks/03_preview_parquets.ipynb
@@ -1,0 +1,66 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b1a2c3d4",
+   "metadata": {},
+   "source": [
+    "# 03 Preview Processed Parquet Files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "e5f6a7b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.append(\"..\")\n",
+    "from src import config\n",
+    "\n",
+    "processed_dir = config.DATA_PROCESSED / \"largest_wide_2018\"\n",
+    "files = sorted(processed_dir.glob('ca_his_raw_2018_*.parquet'))\n",
+    "files[:5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c9d0e1f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from src.utils.parquet_utils import preview_parquet\n",
+    "\n",
+    "sample = files[0] if files else None\n",
+    "if sample is not None:\n",
+    "    df = preview_parquet(sample)\n",
+    "    df\n",
+    "else:\n",
+    "    print('No parquet files found')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "MLProject_570",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a simple notebook to preview processed Parquet files

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687007ac5ee88326bb7a4e31c180f3b8