### PR TITLE
Improve test notebook output formatting

### DIFF
--- a/notebooks/tests/lstm_test_kaza_nopca.ipynb
+++ b/notebooks/tests/lstm_test_kaza_nopca.ipynb
@@ -77,13 +77,13 @@
     }
    ],
    "source": [
-    "# PCA kullanılmıyor\n",
+    "# PCA kullan\u0131lm\u0131yor\n",
     "dataset = TrafficDataset(data_array, X_STEP, Y_STEP)\n",
     "predictor = TrafficPredictor('lstm', dataset.sensors, X_STEP, Y_STEP, pca_model=dataset.pca if False else None)\n",
     "predictor.load_model(config.PROJECT_ROOT.joinpath('models/lstm_kaza_nopca.pt'))\n",
     "loader = DataLoader(dataset, batch_size=10, num_workers=8)\n",
     "preds = predictor.inference(loader)\n",
-    "preds[:5]"
+    "display(pd.DataFrame(preds.squeeze()).head().iloc[:, :10])\n"
    ]
   }
  ],

--- a/notebooks/tests/lstm_test_kaza_pca.ipynb
+++ b/notebooks/tests/lstm_test_kaza_pca.ipynb
@@ -58,7 +58,7 @@
     "predictor.load_model(config.PROJECT_ROOT.joinpath('models/lstm_kaza_pca.pt'))\n",
     "loader = DataLoader(dataset, batch_size=10, num_workers=8)\n",
     "preds = predictor.inference(loader)\n",
-    "preds[:5]"
+    "display(pd.DataFrame(preds.squeeze()).head().iloc[:, :10])\n"
    ]
   }
  ],

--- a/notebooks/tests/lstm_test_trafik_nopca.ipynb
+++ b/notebooks/tests/lstm_test_trafik_nopca.ipynb
@@ -69,13 +69,13 @@
     }
    ],
    "source": [
-    "# PCA kullanılmıyor\n",
+    "# PCA kullan\u0131lm\u0131yor\n",
     "dataset = TrafficDataset(data_array, X_STEP, Y_STEP)\n",
     "predictor = TrafficPredictor('lstm', dataset.sensors, X_STEP, Y_STEP, pca_model=dataset.pca if False else None)\n",
     "predictor.load_model(config.PROJECT_ROOT.joinpath('models/lstm_trafik_nopca.pt'))\n",
     "loader = DataLoader(dataset, batch_size=10, num_workers=8)\n",
     "preds = predictor.inference(loader)\n",
-    "preds[:5]"
+    "display(pd.DataFrame(preds.squeeze()).head().iloc[:, :10])\n"
    ]
   }
  ],

--- a/notebooks/tests/lstm_test_trafik_pca.ipynb
+++ b/notebooks/tests/lstm_test_trafik_pca.ipynb
@@ -51,7 +51,7 @@
     "predictor.load_model(config.PROJECT_ROOT.joinpath('models/lstm_trafik_pca.pt'))\n",
     "loader = DataLoader(dataset, batch_size=10, num_workers=8)\n",
     "preds = predictor.inference(loader)\n",
-    "preds[:5]"
+    "display(pd.DataFrame(preds.squeeze()).head().iloc[:, :10])\n"
    ]
   }
  ],

--- a/notebooks/tests/scgnn_test_kaza_nopca.ipynb
+++ b/notebooks/tests/scgnn_test_kaza_nopca.ipynb
@@ -52,7 +52,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# PCA kullanılmıyor\n",
+    "# PCA kullan\u0131lm\u0131yor\n",
     "dataset = TrafficDataset(data_array, X_STEP, Y_STEP)\n",
     "sensors = dataset.sensors\n",
     "edges = []\n",
@@ -64,7 +64,7 @@
     "predictor.load_model(config.PROJECT_ROOT.joinpath('models/scgnn_kaza_nopca.pt'))\n",
     "loader = DataLoader(dataset, batch_size=10, num_workers=8)\n",
     "preds = predictor.inference(loader)\n",
-    "preds[:5]"
+    "display(pd.DataFrame(preds.squeeze()).head().iloc[:, :10])\n"
    ]
   }
  ],

--- a/notebooks/tests/scgnn_test_kaza_pca.ipynb
+++ b/notebooks/tests/scgnn_test_kaza_pca.ipynb
@@ -64,7 +64,7 @@
     "predictor.load_model(config.PROJECT_ROOT.joinpath('models/scgnn_kaza_pca.pt'))\n",
     "loader = DataLoader(dataset, batch_size=10, num_workers=8)\n",
     "preds = predictor.inference(loader)\n",
-    "preds[:5]"
+    "display(pd.DataFrame(preds.squeeze()).head().iloc[:, :10])\n"
    ]
   }
  ],

--- a/notebooks/tests/scgnn_test_trafik_nopca.ipynb
+++ b/notebooks/tests/scgnn_test_trafik_nopca.ipynb
@@ -1,1 +1,85 @@
-{"cells": [{"cell_type": "markdown", "id": "29cf4a9c", "metadata": {}, "source": ["# SCGNN Test - Trafik - No PCA"]}, {"cell_type": "code", "execution_count": null, "id": "1142b6b6", "metadata": {}, "outputs": [], "source": ["import pandas as pd\n", "import sys\n", "from pathlib import Path\n", "sys.path.append('../..')\n", "from src import config\n", "from src.utils.dataset import TrafficDataset\n", "from src.utils.model import TrafficPredictor\n", "from torch.utils.data import DataLoader"]}, {"cell_type": "code", "execution_count": null, "id": "10bf1615", "metadata": {}, "outputs": [], "source": ["df = pd.read_parquet(config.DATA_INTERIM / 'sample.parquet')\n", "df = df.fillna(0)\n", "X_STEP, Y_STEP = 2, 1\n", "data_array = df.values"]}, {"cell_type": "code", "execution_count": null, "id": "bb29a0af", "metadata": {}, "outputs": [], "source": ["# PCA kullan\u0131lm\u0131yor\n", "dataset = TrafficDataset(data_array, X_STEP, Y_STEP)\n", "sensors = dataset.sensors\n", "edges = []\n", "for i in range(sensors - 1):\n", "    edges.append([i, i + 1])\n", "    edges.append([i + 1, i])\n", "edge_index = torch.tensor(edges, dtype=torch.long).t()\n", "predictor = TrafficPredictor('scgnn', sensors, X_STEP, Y_STEP, edge_index=edge_index, pca_model=dataset.pca if False else None)\n", "predictor.load_model(config.PROJECT_ROOT.joinpath('models/scgnn_trafik_nopca.pt'))\n", "loader = DataLoader(dataset, batch_size=10, num_workers=8)\n", "preds = predictor.inference(loader)\n", "preds[:5]"]}], "metadata": {"kernelspec": {"display_name": ".venv", "language": "python", "name": "python3"}, "language_info": {"codemirror_mode": {"name": "ipython", "version": 3}, "file_extension": ".py", "mimetype": "text/x-python", "name": "python", "nbconvert_exporter": "python", "pygments_lexer": "ipython3", "version": "3.12.3"}}, "nbformat": 4, "nbformat_minor": 5}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "29cf4a9c",
+   "metadata": {},
+   "source": [
+    "# SCGNN Test - Trafik - No PCA"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1142b6b6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "sys.path.append('../..')\n",
+    "from src import config\n",
+    "from src.utils.dataset import TrafficDataset\n",
+    "from src.utils.model import TrafficPredictor\n",
+    "from torch.utils.data import DataLoader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10bf1615",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_parquet(config.DATA_INTERIM / 'sample.parquet')\n",
+    "df = df.fillna(0)\n",
+    "X_STEP, Y_STEP = 2, 1\n",
+    "data_array = df.values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb29a0af",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# PCA kullan\u0131lm\u0131yor\n",
+    "dataset = TrafficDataset(data_array, X_STEP, Y_STEP)\n",
+    "sensors = dataset.sensors\n",
+    "edges = []\n",
+    "for i in range(sensors - 1):\n",
+    "    edges.append([i, i + 1])\n",
+    "    edges.append([i + 1, i])\n",
+    "edge_index = torch.tensor(edges, dtype=torch.long).t()\n",
+    "predictor = TrafficPredictor('scgnn', sensors, X_STEP, Y_STEP, edge_index=edge_index, pca_model=dataset.pca if False else None)\n",
+    "predictor.load_model(config.PROJECT_ROOT.joinpath('models/scgnn_trafik_nopca.pt'))\n",
+    "loader = DataLoader(dataset, batch_size=10, num_workers=8)\n",
+    "preds = predictor.inference(loader)\n",
+    "display(pd.DataFrame(preds.squeeze()).head().iloc[:, :10])\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/tests/scgnn_test_trafik_pca.ipynb
+++ b/notebooks/tests/scgnn_test_trafik_pca.ipynb
@@ -1,1 +1,85 @@
-{"cells": [{"cell_type": "markdown", "id": "d5ea5ce4", "metadata": {}, "source": ["# SCGNN Test - Trafik - PCA"]}, {"cell_type": "code", "execution_count": null, "id": "ebc638e8", "metadata": {}, "outputs": [], "source": ["import pandas as pd\n", "import sys\n", "from pathlib import Path\n", "sys.path.append('../..')\n", "from src import config\n", "from src.utils.dataset import TrafficDataset\n", "from src.utils.model import TrafficPredictor\n", "from torch.utils.data import DataLoader"]}, {"cell_type": "code", "execution_count": null, "id": "4201bb8f", "metadata": {}, "outputs": [], "source": ["df = pd.read_parquet(config.DATA_INTERIM / 'sample.parquet')\n", "df = df.fillna(0)\n", "X_STEP, Y_STEP = 2, 1\n", "data_array = df.values"]}, {"cell_type": "code", "execution_count": null, "id": "28176ea0", "metadata": {}, "outputs": [], "source": ["PCA_COMPONENTS = 5\n", "dataset = TrafficDataset(data_array, X_STEP, Y_STEP, pca_components=PCA_COMPONENTS)\n", "sensors = dataset.sensors\n", "edges = []\n", "for i in range(sensors - 1):\n", "    edges.append([i, i + 1])\n", "    edges.append([i + 1, i])\n", "edge_index = torch.tensor(edges, dtype=torch.long).t()\n", "predictor = TrafficPredictor('scgnn', sensors, X_STEP, Y_STEP, edge_index=edge_index, pca_model=dataset.pca if True else None)\n", "predictor.load_model(config.PROJECT_ROOT.joinpath('models/scgnn_trafik_pca.pt'))\n", "loader = DataLoader(dataset, batch_size=10, num_workers=8)\n", "preds = predictor.inference(loader)\n", "preds[:5]"]}], "metadata": {"kernelspec": {"display_name": ".venv", "language": "python", "name": "python3"}, "language_info": {"codemirror_mode": {"name": "ipython", "version": 3}, "file_extension": ".py", "mimetype": "text/x-python", "name": "python", "nbconvert_exporter": "python", "pygments_lexer": "ipython3", "version": "3.12.3"}}, "nbformat": 4, "nbformat_minor": 5}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d5ea5ce4",
+   "metadata": {},
+   "source": [
+    "# SCGNN Test - Trafik - PCA"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ebc638e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "sys.path.append('../..')\n",
+    "from src import config\n",
+    "from src.utils.dataset import TrafficDataset\n",
+    "from src.utils.model import TrafficPredictor\n",
+    "from torch.utils.data import DataLoader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4201bb8f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_parquet(config.DATA_INTERIM / 'sample.parquet')\n",
+    "df = df.fillna(0)\n",
+    "X_STEP, Y_STEP = 2, 1\n",
+    "data_array = df.values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28176ea0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PCA_COMPONENTS = 5\n",
+    "dataset = TrafficDataset(data_array, X_STEP, Y_STEP, pca_components=PCA_COMPONENTS)\n",
+    "sensors = dataset.sensors\n",
+    "edges = []\n",
+    "for i in range(sensors - 1):\n",
+    "    edges.append([i, i + 1])\n",
+    "    edges.append([i + 1, i])\n",
+    "edge_index = torch.tensor(edges, dtype=torch.long).t()\n",
+    "predictor = TrafficPredictor('scgnn', sensors, X_STEP, Y_STEP, edge_index=edge_index, pca_model=dataset.pca if True else None)\n",
+    "predictor.load_model(config.PROJECT_ROOT.joinpath('models/scgnn_trafik_pca.pt'))\n",
+    "loader = DataLoader(dataset, batch_size=10, num_workers=8)\n",
+    "preds = predictor.inference(loader)\n",
+    "display(pd.DataFrame(preds.squeeze()).head().iloc[:, :10])\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- make prediction outputs more readable in all test notebooks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889464930ac83269e9949f783595ada